### PR TITLE
Final cleanup

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -275,6 +275,10 @@ ul#taglist {
     float: left;
 }
 
+ul#taglist li {
+    margin-left: 0px;
+}
+
 /* alerts */
 .alert, .panel {
     padding: 8px 35px 8px 14px;

--- a/controllers/history.php
+++ b/controllers/history.php
@@ -9,25 +9,10 @@ use PicoFarad\Template;
 Router\get_action('history', function() {
 
     $offset = Request\int_param('offset', 0);
-    $group_id = Request\int_param('group_id', null);
-    $feed_id = Request\int_param('feed_id', null);
-
-    // feed_id and group_id can be present at the same time, if a feed of a
-    // group is viewed. Show only items of this feed instead of the whole group.
-    if (!is_null($feed_id)) {
-        $feed_ids = array($feed_id);
-    }
-    elseif (!is_null($group_id)) {
-        $feed_ids = Model\Tag\get_feeds_by_tag($group_id);
-    }
-    else {
-        $feed_ids = null;
-    }
-
-    $nb_items = Model\Item\count_by_status('read', $feed_ids);
+    $nb_items = Model\Item\count_by_status('read');
     $items = Model\Item\get_all_by_status(
         'read',
-        $feed_ids,
+        null,
         $offset,
         Model\Config\get('items_per_page'),
         'updated',
@@ -37,8 +22,6 @@ Router\get_action('history', function() {
     Response\html(Template\layout('history', array(
         'favicons' => Model\Feed\get_item_favicons($items),
         'original_marks_read' => Model\Config\get('original_marks_read'),
-        'feed_id' => $feed_id,
-        'group_id' => $group_id,
         'items' => $items,
         'order' => '',
         'direction' => '',
@@ -56,12 +39,7 @@ Router\get_action('history', function() {
 // Confirmation box to flush history
 Router\get_action('confirm-flush-history', function() {
 
-    $group_id = Request\int_param('group_id', null);
-    $feed_id = Request\int_param('feed_id', null);
-
     Response\html(Template\layout('confirm_flush_items', array(
-        'feed_id' => $feed_id,
-        'group_id' => $group_id,
         'nb_unread_items' => Model\Item\count_by_status('unread'),
         'menu' => 'history',
         'title' => t('Confirmation')
@@ -71,22 +49,6 @@ Router\get_action('confirm-flush-history', function() {
 // Flush history
 Router\get_action('flush-history', function() {
 
-    $group_id = Request\int_param('group_id', null);
-    $feed_id = Request\int_param('feed_id', null);
-
-    // feed_id and group_id can be present at the same time, if a feed of a
-    // group is viewed. Flush only items of this feed instead of the whole group.
-    if (!is_null($feed_id)) {
-        Model\Item\mark_feed_as_removed($feed_id);
-        Response\redirect('?action=history&group_id='.$group_id.'&feed_id='.$feed_id);
-    }
-    elseif (!is_null($group_id)) {
-        Model\Item\mark_group_as_removed($group_id);
-        Response\redirect('?action=history&group_id='.$group_id);
-    }
-    else {
-        Model\Item\mark_all_as_removed();
-        Response\redirect('?action=history');
-    }
-
+    Model\Item\mark_all_as_removed();
+    Response\redirect('?action=history');
 });

--- a/controllers/item.php
+++ b/controllers/item.php
@@ -15,18 +15,10 @@ Router\get_action('unread', function() {
     $direction = Request\param('direction', Model\Config\get('items_sorting_direction'));
     $offset = Request\int_param('offset', 0);
     $group_id = Request\int_param('group_id', null);
-    $feed_id = Request\int_param('feed_id', null);
+    $feed_ids = null;
 
-    // feed_id and group_id can be present at the same time, if a feed of a
-    // group is viewed. Show only items of this feed instead of the whole group.
-    if (!is_null($feed_id)) {
-        $feed_ids = array($feed_id);
-    }
-    elseif (!is_null($group_id)) {
+    if (!is_null($group_id)) {
         $feed_ids = Model\Tag\get_feeds_by_tag($group_id);
-    }
-    else {
-        $feed_ids = null;
     }
 
     $items = Model\Item\get_all_by_status(
@@ -37,6 +29,7 @@ Router\get_action('unread', function() {
         $order,
         $direction
     );
+
     $nb_items = Model\Item\count_by_status('unread', $feed_ids);
     $nb_unread_items = Model\Item\count_by_status('unread');
 
@@ -51,7 +44,6 @@ Router\get_action('unread', function() {
         'order' => $order,
         'direction' => $direction,
         'display_mode' => Model\Config\get('items_display_mode'),
-        'feed_id' => $feed_id,
         'group_id' => $group_id,
         'items' => $items,
         'nb_items' => $nb_items,
@@ -175,23 +167,15 @@ Router\post_action('mark-item-unread', function() {
 Router\get_action('mark-all-read', function() {
 
     $group_id = Request\int_param('group_id', null);
-    $feed_id = Request\int_param('feed_id', null);
 
-    // feed_id and group_id can be present at the same time, if a feed of a
-    // group is viewed. Mark only items of this feed as read instead of the
-    // whole group.
-    if (!is_null($feed_id)) {
-        Model\Item\mark_feed_as_read($feed_id);
-        Response\redirect('?action=unread&group_id='.$group_id.'&feed_id='.$feed_id);
-    }
-    elseif (!is_null($group_id)) {
+    if (!is_null($group_id)) {
         Model\Item\mark_group_as_read($group_id);
-        Response\redirect('?action=unread&group_id='.$group_id);
     }
     else {
         Model\Item\mark_all_as_read();
-        Response\redirect('?action=unread');
     }
+
+    Response\redirect('?action=unread');
 });
 
 // Mark all unread items as read for a specific feed

--- a/models/feed.php
+++ b/models/feed.php
@@ -94,7 +94,6 @@ function get_all_favicons()
 // Update feed information
 function update(array $values)
 {
-    // TODO: does it work?
     Database::get('db')->startTransaction();
 
     $result = Database::get('db')

--- a/models/item.php
+++ b/models/item.php
@@ -348,31 +348,6 @@ function mark_all_as_removed()
         ->save(array('status' => 'removed', 'content' => ''));
 }
 
-// Mark all read items of a feed to removed
-function mark_feed_as_removed($feed_id)
-{
-    return Database::get('db')
-        ->table('items')
-        ->eq('status', 'read')
-        ->eq('bookmark', 0)
-        ->eq('feed_id', $feed_id)
-        ->save(array('status' => 'removed', 'content' => ''));
-}
-
-// Mark all read items of a group to removed
-function mark_group_as_removed($group_id)
-{
-    // workaround for missing update with join
-    $feed_ids = Tag\get_feeds_by_tag($group_id);
-
-    return Database::get('db')
-        ->table('items')
-        ->eq('status', 'read')
-        ->eq('bookmark', 0)
-        ->in('feed_id', $feed_ids)
-        ->save(array('status' => 'removed', 'content' => ''));
-}
-
 // Mark all items of a feed as read
 function mark_feed_as_read($feed_id)
 {

--- a/models/tag.php
+++ b/models/tag.php
@@ -11,7 +11,6 @@ use PicoDb\Database;
  */
 function get_all()
 {
-    // TODO: Who is responsible for sorting the data in MVC?
     return Database::get('db')
             ->table('tag')
             ->orderBy('title')
@@ -85,7 +84,6 @@ function get_tag_id($title)
  */
 function get_feeds_by_tag($tag_id)
 {
-    // TODO: does it belong to Model\Tag?
     return Database::get('db')
             ->table('feed_tag')
             ->eq('tag_id', $tag_id)

--- a/templates/confirm_flush_items.php
+++ b/templates/confirm_flush_items.php
@@ -5,6 +5,6 @@
 <p class="alert alert-info"><?= t('Do you really want to remove these items from your history?') ?></p>
 
 <div class="form-actions">
-    <a href="?action=flush-history<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?><?= is_null($feed_id) ? '' : '&amp;feed_id='.$feed_id ?>" class="btn btn-red"><?= t('Remove') ?></a>
+    <a href="?action=flush-history" class="btn btn-red"><?= t('Remove') ?></a>
     <?= t('or') ?> <a href="?action=history"><?= t('cancel') ?></a>
 </div>

--- a/templates/history.php
+++ b/templates/history.php
@@ -5,7 +5,7 @@
     <div class="page-header">
         <h2><?= t('History') ?><span id="page-counter"><?= isset($nb_items) ? $nb_items : '' ?></span></h2>
         <ul>
-            <li><a href="?action=confirm-flush-history<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?><?= is_null($feed_id) ? '' : '&amp;feed_id='.$feed_id ?>"><?= t('flush all items') ?></a></li>
+            <li><a href="?action=confirm-flush-history"><?= t('flush all items') ?></a></li>
         </ul>
     </div>
 
@@ -26,7 +26,7 @@
             )) ?>
         <?php endforeach ?>
 
-        <?= \PicoFarad\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'feed_id' => $feed_id, 'group_id' => $group_id)) ?>
+        <?= \PicoFarad\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction)) ?>
     </section>
 
 <?php endif ?>

--- a/templates/unread_items.php
+++ b/templates/unread_items.php
@@ -2,13 +2,18 @@
 
     <div class="page-header">
         <h2><?= t('Unread') ?><span id="page-counter"><?= isset($nb_items) ? $nb_items : '' ?></span></h2>
-        <ul id="taglist">
-            <?php foreach ($tags as $tag): ?>
-            <li>
-                <a href="?action=unread&group_id=<?=$tag['id']?>" class="tag"><?=$tag['title']?></a>
-            </li>
-            <?php endforeach ?>
-        </ul>
+        <?php if (!empty($tags)): ?>
+        <nav>
+            <ul id="taglist">
+                <?php foreach ($tags as $tag): ?>
+                <li  <?= $tag['id'] == $group_id ? 'class="active"' : '' ?>>
+                    <a href="?action=unread&group_id=<?=$tag['id']?>"><?=$tag['title']?></a>
+                </li>
+                <?php endforeach ?>
+            </ul>
+        </nav>
+        <?php endif ?>
+
         <ul>
             <li>
                 <a href="?action=unread<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?>&amp;order=updated&amp;direction=<?= $direction == 'asc' ? 'desc' : 'asc' ?>"><?= tne('sort by date %s(%s)%s', '<span class="hide-mobile">',$direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>

--- a/templates/unread_items.php
+++ b/templates/unread_items.php
@@ -11,10 +11,10 @@
         </ul>
         <ul>
             <li>
-                <a href="?action=unread<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?><?= is_null($feed_id) ? '' : '&amp;feed_id='.$feed_id ?>&amp;order=updated&amp;direction=<?= $direction == 'asc' ? 'desc' : 'asc' ?>"><?= tne('sort by date %s(%s)%s', '<span class="hide-mobile">',$direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>
+                <a href="?action=unread<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?>&amp;order=updated&amp;direction=<?= $direction == 'asc' ? 'desc' : 'asc' ?>"><?= tne('sort by date %s(%s)%s', '<span class="hide-mobile">',$direction == 'desc' ? t('older first') : t('most recent first'), '</span>') ?></a>
             </li>
             <li>
-                <a href="?action=mark-all-read<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?><?= is_null($feed_id) ? '' : '&amp;feed_id='.$feed_id ?>"><?= t('mark all as read') ?></a>
+                <a href="?action=mark-all-read<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?>"><?= t('mark all as read') ?></a>
             </li>
         </ul>
     </div>
@@ -36,9 +36,9 @@
             <?php endforeach ?>
 
             <div id="bottom-menu">
-                <a href="?action=mark-all-read<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?><?= is_null($feed_id) ? '' : '&amp;feed_id='.$feed_id ?>"><?= t('mark all as read') ?></a>
+                <a href="?action=mark-all-read<?= is_null($group_id) ? '' : '&amp;group_id='.$group_id ?>"><?= t('mark all as read') ?></a>
             </div>
 
-            <?= \PicoFarad\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'feed_id' => $feed_id, 'group_id' => $group_id)) ?>
+            <?= \PicoFarad\Template\load('paging', array('menu' => $menu, 'nb_items' => $nb_items, 'items_per_page' => $items_per_page, 'offset' => $offset, 'order' => $order, 'direction' => $direction, 'group_id' => $group_id)) ?>
         <?php endif ?>
     </section>


### PR DESCRIPTION
I'm finished with polishing and testing. The changed tag list looks like the following:

![miniflux](https://cloud.githubusercontent.com/assets/4547948/9044973/7e02c726-3a20-11e5-8f0a-e6513252b5f9.JPG)

I've tested:
- displaying only a group of unread
- displaying all unread
- mark a single feed as read (subscription page)
- mark a group as read
- mark all unread as read
- FeverAPI: mark a single feed as read
- FeverAPI: mark a group as read
- FeverAPI: mark all unread as read

No issues found so far.

We should mention in the commit/PR that the "virtual group" ALL isn't exported any longer via Fever API. The group was used as catch-all for all feeds. That isn't required at all. Left hand side is a screenshot of the iOS Reeder App without any tags and on the right side a mix of tagged and untagged feeds:

![reeder](https://cloud.githubusercontent.com/assets/4547948/9044992/939c54e4-3a20-11e5-83d9-297abf966244.JPG)

In advance of sending a PR, we/you should reset the fork and squash our commits into one. You can export all of our changes as a single patch file using this url: https://github.com/miniflux/miniflux/compare/master...kordianbruck:master.diff. Give me a short reply if I should do the squashing.
